### PR TITLE
npm link correction according to official documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,10 @@ logs/
 *.log
 *.taskpaper
 TODO.md
-NOTES.md
 example/
 .nyc_output/
 .vscode/
 .temp/
 custom-templates/
 src/unused/
+.idea/

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -544,7 +544,7 @@ module.exports = {
           toolbox.print.success(`${toolbox.colors.yellow(toolbox.commandName)} Project Created Successfully`, 'SUCCESS')
           toolbox.print.notice('\n👉 Next Steps:\n')
           toolbox.print.notice(`   ${toolbox.colors.gray('$')} cd ${toolbox.commandName}`)
-          toolbox.print.notice(`   ${toolbox.colors.gray('$')} ${this.answers.pkgMgr} link ${toolbox.commandName}`)
+          toolbox.print.notice(`   ${toolbox.colors.gray('$')} ${this.answers.pkgMgr} link`)
           toolbox.print.debug(colors.dim('     info => https://docs.npmjs.com/cli/v6/commands/npm-link'))
           toolbox.print.notice(`   ${toolbox.colors.gray('$')} ${toolbox.commandName} --help\n`)
           console.log(colors.keyword('pink').italic('   🐶 Woof!'))


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

**What changes did you make? (Give an overview)**
I updated the `next steps` part, because the `npm link` was not 100% correct.  
if you are in the project folder, then you only need a `npm link` and not a `npm link <<project>>`  

official docu:  
> First, `npm link` in a package folder will create a symlink in the global folder


you only need the project name if you link it in another folder:  
> Next, in some other location, `npm link package-name` will create a symbolic link from globally-installed package-name to node_modules/ of the current folder